### PR TITLE
chore(app-config): add typedoc generation

### DIFF
--- a/packages/game-app/.gitignore
+++ b/packages/game-app/.gitignore
@@ -23,3 +23,5 @@ yarn-debug.log*
 yarn-error.log*
 /cypress/screenshots
 /cypress/videos
+
+docs

--- a/packages/game-app/.typedoc-plugin-external-module-name.js
+++ b/packages/game-app/.typedoc-plugin-external-module-name.js
@@ -1,0 +1,23 @@
+module.exports = function customMappingFunction(explicit, implicit, path, reflection, context) {
+
+  try {
+    if (explicit) {
+      return explicit;
+    }
+    if (implicit === 'src\\_shared') {
+      return '@shared';
+    }
+    if (implicit === 'src') {
+      return 'root';
+    }
+    if (implicit.startsWith('src\\_shared\\')) {
+      // if its in shared return @shared/{folderName}
+      return `@shared/${implicit.replace('src\\_shared\\', '').split('\\')[0]}`;
+    } else {
+      return implicit.replace('src\\', '').split('\\')[0];
+    }
+  }catch (e){
+    console.error(e);
+    return implicit;
+  }
+};

--- a/packages/game-app/package-lock.json
+++ b/packages/game-app/package-lock.json
@@ -9995,6 +9995,27 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -10164,6 +10185,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
       "dev": true
     },
     "hmac-drbg": {
@@ -10780,6 +10807,12 @@
           }
         }
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -13776,6 +13809,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
@@ -13832,6 +13871,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.7.tgz",
+      "integrity": "sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -17212,6 +17257,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -18378,6 +18432,17 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -19873,6 +19938,41 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
+      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^9.0.1",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.2.0",
+        "lodash": "^4.17.20",
+        "lunr": "^2.3.9",
+        "marked": "^1.1.1",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "semver": "^7.3.2",
+        "shelljs": "^0.8.4",
+        "typedoc-default-themes": "^0.11.4"
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
+      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+      "dev": true
+    },
+    "typedoc-plugin-external-module-name": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-4.0.5.tgz",
+      "integrity": "sha512-9u4Eu8BdEZ23M5v9fZzHtQJvWFmYOcwQuxhXka8WCLrTFgCJtpeHsl/+p8Ud40BNJDRIIjxPcpT1PC1fMF1pMA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.1.2",
+        "semver": "^7.1.1"
+      }
+    },
     "typescript": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
@@ -19918,6 +20018,13 @@
         "simple-concat": "^1.0.0",
         "xtend": "^4.0.1"
       }
+    },
+    "uglify-js": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.3.tgz",
+      "integrity": "sha512-feZzR+kIcSVuLi3s/0x0b2Tx4Iokwqt+8PJM7yRHKuldg4MLdam4TCFeICv+lgDtuYiCtdmrtIP+uN9LWvDasw==",
+      "dev": true,
+      "optional": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -21808,6 +21915,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "workbox-background-sync": {

--- a/packages/game-app/package.json
+++ b/packages/game-app/package.json
@@ -20,7 +20,8 @@
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",
     "e2e:open": "npx cypress open",
-    "e2e:run": "npx cypress run"
+    "e2e:run": "npx cypress run",
+    "generate:doc": "npx typedoc"
   },
   "eslintConfig": {
     "extends": [
@@ -57,6 +58,8 @@
     "react-app-rewire-alias": "^0.1.9",
     "react-app-rewired": "^2.1.8",
     "react-scripts": "4.0.1",
+    "typedoc": "^0.19.2",
+    "typedoc-plugin-external-module-name": "^4.0.5",
     "typescript": "^4.1.3"
   }
 }


### PR DESCRIPTION
Itegrate typedoc generation for react app with custom module name resolution.

The naming conventions consider a folder structure like this:
.
└── src
    ├── _shared
    │   ├── util1
    │   ├── util2
    │   └── util3
    ├── login
    ├── signup
    └── dashboard


Closes #8 