### PR TITLE
refactor(app-general): add request key in action type for readability…

### DIFF
--- a/packages/game-app/src/_shared/requests-status/sagaIntegrations.ts
+++ b/packages/game-app/src/_shared/requests-status/sagaIntegrations.ts
@@ -1,6 +1,6 @@
 import { RequestsKeys } from './requestsKeys';
 import { call, put } from 'redux-saga/effects';
-import { actions as loadingActions } from './index';
+import { actions } from './index';
 import { SagaIterator } from 'redux-saga';
 
 export function addRequestStatusManagement<T = any, Fn extends (...args: any[]) => SagaIterator<T> = () => any>(
@@ -9,11 +9,11 @@ export function addRequestStatusManagement<T = any, Fn extends (...args: any[]) 
 ) {
   return function* composed(...args: Parameters<Fn>) {
     try {
-      yield put(loadingActions.startRequest(requestKey));
+      yield put(actions.startRequest(requestKey));
       yield call(gen, ...args);
-      yield put(loadingActions.requestSuccess(requestKey));
+      yield put(actions.requestSuccess(requestKey));
     } catch (e) {
-      yield put(loadingActions.requestError({ key: requestKey, error: e }));
+      yield put(actions.requestError({ key: requestKey, error: e }));
     }
   };
 }

--- a/packages/game-app/src/_shared/requests-status/slice.ts
+++ b/packages/game-app/src/_shared/requests-status/slice.ts
@@ -1,48 +1,74 @@
 import { RequestsKeys } from './requestsKeys';
 import { RequestStatus } from './types';
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AnyAction, createSlice } from '@reduxjs/toolkit';
 
 export type State = {
   [key in keyof RequestsKeys]?: RequestStatus;
 };
 
+export const actions = {
+  resetStatus: (key: keyof RequestsKeys) => ({ type: `requestsStatus/resetStatus/${key}`, payload: key }),
+  startRequest: (key: keyof RequestsKeys) => ({ type: `requestsStatus/startRequest/${key}`, payload: key }),
+  requestError: (data: { key: keyof RequestsKeys; error: { message: string; code: string } }) => ({
+    type: `requestsStatus/requestError/${data.key}`,
+    payload: data,
+  }),
+  requestSuccess: (key: keyof RequestsKeys) => ({ type: `requestsStatus/requestSuccess/${key}`, payload: key }),
+};
+
+function isResetStatusAction(action: AnyAction): action is ReturnType<typeof actions.resetStatus> {
+  return (action.type as string).startsWith('requestsStatus/resetStatus/');
+}
+
+function isStartRequestAction(action: AnyAction): action is ReturnType<typeof actions.startRequest> {
+  return (action.type as string).startsWith('requestsStatus/startRequest/');
+}
+
+function isRequestErrorAction(action: AnyAction): action is ReturnType<typeof actions.requestError> {
+  return (action.type as string).startsWith('requestsStatus/requestError/');
+}
+
+function isRequestSuccessAction(action: AnyAction): action is ReturnType<typeof actions.requestSuccess> {
+  return (action.type as string).startsWith('requestsStatus/requestSuccess/');
+}
+
 const requestManagementSlice = createSlice({
   name: 'requestsStatus',
   initialState: {} as State,
-  reducers: {
-    resetStatus(state, action: PayloadAction<keyof RequestsKeys>) {
-      state[action.payload] = {
-        loading: false,
-        success: false,
-        error: undefined,
-      };
-    },
-    startRequest(state, action: PayloadAction<keyof RequestsKeys>) {
-      state[action.payload] = {
-        loading: true,
-        success: false,
-        error: undefined,
-      };
-    },
-    requestError(state, action: PayloadAction<{ key: keyof RequestsKeys; error: { message: string; code: string } }>) {
-      state[action.payload.key] = {
-        loading: false,
-        success: false,
-        error: action.payload.error,
-      };
-    },
-    requestSuccess(state, action: PayloadAction<keyof RequestsKeys>) {
-      state[action.payload] = {
-        loading: false,
-        success: true,
-        error: undefined,
-      };
-    },
+  extraReducers: builder => {
+    builder
+      .addMatcher(isResetStatusAction, (state, action) => {
+        state[action.payload] = {
+          loading: false,
+          success: false,
+          error: undefined,
+        };
+      })
+      .addMatcher(isStartRequestAction, (state, action) => {
+        state[action.payload] = {
+          loading: true,
+          success: false,
+          error: undefined,
+        };
+      })
+      .addMatcher(isRequestErrorAction, (state, action) => {
+        state[action.payload.key] = {
+          loading: false,
+          success: false,
+          error: action.payload.error,
+        };
+      })
+      .addMatcher(isRequestSuccessAction, (state, action) => {
+        state[action.payload] = {
+          loading: false,
+          success: true,
+          error: undefined,
+        };
+      });
   },
+  reducers: {},
 });
 
 export default requestManagementSlice.reducer;
-
-export const actions = requestManagementSlice.actions;
 
 export const name = requestManagementSlice.name;


### PR DESCRIPTION
Requests status management actions appear all the same in the devtools because the type does not depend on the request key.

This PR adds the request key in the action type and change reducers to match action correctly